### PR TITLE
fix: changed max adjacency to 2 and added experimental disclaimer

### DIFF
--- a/src/SilksongRandomizer/MapLogicEvaluator.cs
+++ b/src/SilksongRandomizer/MapLogicEvaluator.cs
@@ -367,7 +367,8 @@ namespace SilksongRandomizer
                    requirement.LogicUnknown;
         }
 
-        private const int MaxAdjacentRooms = 4;
+        // Setting this to 2 to lower adjacencies in massive rooms like Bone Bottom town.
+        private const int MaxAdjacentRooms = 2;
         private const string RoomNodePrefix = "Room Node: ";
         private const string RoomEventPrefix = "Room Event: ";
         // Grey already used in repository. ^-^

--- a/src/SilksongRandomizer/Plugin.cs
+++ b/src/SilksongRandomizer/Plugin.cs
@@ -163,9 +163,9 @@ namespace SilksongRandomizer
 
             showMapMarkerLogic = Config.Bind(
                 "Map Markers",
-                "Show Logic",
+                "Show Logic (Experimental)",
                 false,
-                "Show logic requirements when focusing a map marker."
+                "Checks nearby rooms for required logic for a check while focusing a map marker."
             );
         }
 


### PR DESCRIPTION
Small changes to account for large rooms like Bone Bottom and added an experimental disclaimer to the option text.

There's still some weird listings for checks in particularly large rooms but it should still help with a guideline of what items can be required for a check.