### PR TITLE
fix: vanilla bellway and ventrica routing

### DIFF
--- a/APWorld/silksong/native_regions.py
+++ b/APWorld/silksong/native_regions.py
@@ -112,6 +112,8 @@ def native_source_requires_assumption(
     pollip_heart_count: int,
     anchor_requirement_name: str | None,
 ) -> bool:
+    if reward_name.startswith(("Bellway: ", "Ventrica: ")):
+        return False
     child = build_location_rule(
         location_name,
         pollip_heart_count=pollip_heart_count,

--- a/APWorld/silksong/requirements.py
+++ b/APWorld/silksong/requirements.py
@@ -4966,8 +4966,6 @@ _ROOM_GRAPH_ESTABLISHED_ONLY_LOCATIONS: frozenset[str] = frozenset(
         # These two Deep Docks checks do not have room-graph records.
         'Deep Docks - Rosary Cache #1',
         'Deep Docks - Rosary Cache #2',
-        *LOCATION_NAMES_BY_CATEGORY['Bellway'],
-        *LOCATION_NAMES_BY_CATEGORY['Ventrica'],
     )
 )
 

--- a/APWorld/silksong/requirements.py
+++ b/APWorld/silksong/requirements.py
@@ -4966,6 +4966,8 @@ _ROOM_GRAPH_ESTABLISHED_ONLY_LOCATIONS: frozenset[str] = frozenset(
         # These two Deep Docks checks do not have room-graph records.
         'Deep Docks - Rosary Cache #1',
         'Deep Docks - Rosary Cache #2',
+        *LOCATION_NAMES_BY_CATEGORY['Bellway'],
+        *LOCATION_NAMES_BY_CATEGORY['Ventrica'],
     )
 )
 


### PR DESCRIPTION
"Path: Bellways" requirement seems to be achieved with just having access to Bone Bottom with ```randomized_stations``` and Bell Beast Killed with ```Bell Beast Required``` on Vanilla Bellway Randomization. I believe this would apply to Ventrica as well since it's handled similarly so I attempted to catch that same edge case.

We should just be able to return false for Bellways and Ventricas in the native source assumption as being able to access the Bone Bottom Bellway Path shouldn't allow for the generation to place unreachable Bellways into early spheres.

The requirements can also add all Bellway and Ventrica locations by the category to make sure that the Bellway is reachable on the map before placing it into the sphere.

Here is an example of the sphere generation I had using this change:

> "Path: Bellways" requirement seems to be achieved with access to Bone Bottom with ```randomized_stations``` and Bell Beast Killed with ```Bell Beast Required```.

We should just be able to return false for Bellways and Ventricas in the native source assumption as being able to access the Bone Bottom Bellway Path shouldn't allow for the generation to place unreachable Bellways into early spheres.

The requirements can also add all Bellway and Ventrica locations by the category to make sure that the Bellway is reachable on the map before placing it into the sphere.

This should probably get some more tests to make sure it's not affecting other seeds but from what I understand the change should have no impact on anything other than Vanilla Bellways and Ventricas.

Here is an example of the sphere generation I had using this change which makes much more sense to me:

<img width="764" height="778" alt="image" src="https://github.com/user-attachments/assets/f24e2797-e440-4845-beb3-442377fe5bac" />
