### PR TITLE
fix(routing): vanilla ventrica and bellway routing

### DIFF
--- a/APWorld/silksong/native_regions.py
+++ b/APWorld/silksong/native_regions.py
@@ -112,6 +112,8 @@ def native_source_requires_assumption(
     pollip_heart_count: int,
     anchor_requirement_name: str | None,
 ) -> bool:
+    if reward_name.startswith(("Bellway: ", "Ventrica: ")):
+        return False
     child = build_location_rule(
         location_name,
         pollip_heart_count=pollip_heart_count,


### PR DESCRIPTION
 "Path: Bellways" requirement seems to be achieved with just having access to Bone Bottom with ```randomized_stations``` and Bell Beast Killed with ```Bell Beast Required``` on Vanilla Bellway Randomization. I believe this would apply to Ventrica as well since it's handled similarly so I attempted to catch that same edge case.

We should just be able to return false for Bellways and Ventricas in the native source assumption as being able to access the Bone Bottom Bellway Path shouldn't allow for the generation to place unreachable Bellways into early spheres.

Here is an example of the sphere generation I had using this change which makes much more sense to me:

<img width="1300" height="697" alt="image" src="https://github.com/user-attachments/assets/e38bcb73-e866-41cb-954f-e0cf10718669" />

