### PR TITLE
fix(sprint): patch HeroDash to account for progressive swift step lvl 1

### DIFF
--- a/src/SilksongRandomizer/Patches/HeroControllerPatches.cs
+++ b/src/SilksongRandomizer/Patches/HeroControllerPatches.cs
@@ -4,7 +4,6 @@ using HarmonyLib;
 using HutongGames.PlayMaker;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Text;

--- a/src/SilksongRandomizer/Patches/HeroControllerPatches.cs
+++ b/src/SilksongRandomizer/Patches/HeroControllerPatches.cs
@@ -4,6 +4,7 @@ using HarmonyLib;
 using HutongGames.PlayMaker;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Text;
@@ -343,6 +344,21 @@ namespace SilksongRandomizer.Patches
                             )
                         );
                 }
+            }
+        }
+
+        [HarmonyPatch(typeof(HeroController), "HeroDash")]
+        internal static class HeroController_HeroDash_Patch
+        {
+            [HarmonyPrefix]
+            private static bool Prefix(HeroController __instance)
+            {
+                SaveState state = SaveState.Instance;
+                if (state == null || !state.IsRandomized(ItemType.Skill))
+                {
+                    return true;
+                }
+                return state.canDash || WidowSequenceSafety.CanUseEmergencySwiftStep(state);
             }
         }
 


### PR DESCRIPTION
On current patch (v0.4.4), you can do a sprint jump, press dash to `DASH CANCEL` and then dash again resulting in a dash without Progressive Swift Step Lvl. 2 through the following route:

`SetStartWithDash` to `RegainControl` to `HeroDash` which ignores the placed `CanDash` patch that is part of the Progressive Swift Step patch.

I prefixed `HeroDash` so it can only be run when Dash is owned and passed the emergency Widow Sequence that I saw in the normal `CanDash` function.

I tested this with the original bug and it no longer occurs with Progressive Swift Step 1.

I then tested Dash on a bunch of other things after all these abilities and in conjunction with each other as well:

- Progressive Swift Step Lvl. 2
- Sprint Jump
- Faydown Cloak
- Drifter's Cloak
- Clawline
- Silk Soar
- Cling Grip

I believe this should have fixed the issue while avoiding the ignore that Dash Cancel sets for the vanilla `Sprint Air` state but playtesters may find something...